### PR TITLE
Added Base Bar

### DIFF
--- a/croncert-config.yml
+++ b/croncert-config.yml
@@ -564,6 +564,40 @@ scrapers:
   # Lausanne
   ############
 
+  - name: BaseBar
+    url: https://stadtkonzerte.ch/locations/base-bar-lausanne
+    item: body.body > div.page > div.page__column.page__column--left > div.container > div.content > div.sk_gig-day-container > div.gig_day
+    fields:
+      - name: location
+        value: Base Bar
+      - name: city
+        value: Lausanne
+      - name: "type"
+        value: "concert"
+      - name: "sourceUrl" # This is needed to uniquely identify this scraper
+        value: https://basebarlausanne.ch/evenements/
+      - name: date
+        type: date
+        components:
+          - covers:
+              day: true
+              month: true
+              year: true
+            location:
+              selector: div.row.visible-xs.visible-sm.sticky-div > h2.col-xs-12.col-md-offset-1.col-md-10.date-header > span.day
+            layout: ["Mon 2. January 2006"] # adapt according to actual format
+        date_location: "Europe/Berlin" # example
+        date_language: "de_DE" # example
+      - name: title
+        type: text
+        location:
+          selector: div.row.sk_indent.gig.xs-card > div.col-xs-12.col-sm-8.col-md-7.card > div.artist > a
+      - name: url
+        type: url
+        location:
+          selector: div.row.sk_indent.gig.xs-card > div.col-xs-12.col-sm-8.col-md-7.card > div.hidden-xs > div.tickets > a.boxoffice.ticket_link.information
+          attr: href
+
   - name: Docks
     url: https://www.docks.ch/programme/
     item: body.page-template.page-template-page-programme.page-template-page-programme-php.page.page-id-3652 > div.wrapper.wrapper-programme > div.container-fluid > div.home-program.position-relative > div.row.programme-container > div.col-xxl-10 > div.row.special-row > div.mix.col-sm-6.col-md-5.col-lg-4.col-xl-4.col-xxl-4.concerts


### PR DESCRIPTION
I do wonder a bit about this one. The venue website itself has no text for events, only posters. However, they do have a presence on Stadkonzert, so I checked out their TOS, and there isn't one. The scraper is limited to the one venue, so there shouldn't be any duplicates.