### PR TITLE
Added events of the type "Spectacle" since some are concerts.

### DIFF
--- a/croncert-config.yml
+++ b/croncert-config.yml
@@ -1159,6 +1159,9 @@ scrapers:
       - field: "eventType"
         regex: "Concert"
         match: true
+      - field: "eventType"
+        regex: "Spectacle"
+        match: true
 
   - name: Premices
     url: https://www.premices.ch/programme


### PR DESCRIPTION
We were missing a very concert-like event at Pôle Sud since they had filed it under "Spectacle", so I've added that to the inclusive filter.