### PR TITLE
Aligned the Octogone in Pully with OpenStreetMap

### DIFF
--- a/concert-config.yml
+++ b/concert-config.yml
@@ -3341,11 +3341,11 @@ scrapers:
       - name: "type"
         value: "concert"
       - name: "city"
-        value: "Lausanne"
+        value: "Pully"
       - name: country
         value: Switzerland
       - name: "location"
-        value: "L’Octogone Theatre De Pully"
+        value: "L’Octogone"
       - name: "sourceUrl"
         value: "https://theatre-octogone.ch/categorie/musique/"
       - name: comment


### PR DESCRIPTION
This puts the theatre outside of Lausanne proper (it is) and in the neighbouring city of Pully, but aligns it with OpenStreetMap, which is probably useful in General.