### PR TITLE
Added an image tag for Sender

### DIFF
--- a/concert-config.yml
+++ b/concert-config.yml
@@ -6643,6 +6643,14 @@ scrapers:
         type: "url"
         location:
           selector: "" # An empty string means that we look in the event node itself for an href
+      - name: "imageUrl"
+        type: "text"
+        location:
+          selector: .event-preview__image > source:nth-child(1)
+          attr: data-srcset
+          regex_extract: 
+            exp: "[^ ]+"
+            index: 0
       - name: "date"
         type: "date"
         components:


### PR DESCRIPTION
This is the opposite of the usual problem. The venue website is so advanced that it's hard for my dumb import script to find the images in their <picture> tag. It would be easier to do it up front in this case.