### PR TITLE
24 hour clock bug

### DIFF
--- a/concert-config.yml
+++ b/concert-config.yml
@@ -2675,7 +2675,7 @@ scrapers:
             transform:
               - type: regex-replace
                 regex: 00:00
-                replace: 11:59
+                replace: 23:59
         date_language: fr_FR
         date_location: CET
       - name: imageUrl


### PR DESCRIPTION
There I go thinking like a dumb American. You think I would have internalized the 24 hour clock by now.

This fix moves the events to a minute before midnight on the 24 hour clock, instead of a minute before noon.