### PR TITLE
Static image for Chorus, because they don't do event images

### DIFF
--- a/config/lausanne.yml
+++ b/config/lausanne.yml
@@ -116,6 +116,8 @@ scrapers:
         value: "concert"
       - name: "sourceUrl"
         value: "https://chorus.ch/programme/"
+      - name: "imageUrl"
+        value: "https://chorus.ch/wp-content/uploads/2023/08/Logo_Chorus_36.jpg"
       - name: date
         type: date
         components:


### PR DESCRIPTION
And for whatever reason the programmatic ways I've found to do it find the worst possible image.