### PR TITLE
Aligned the name of Schüür with openstreetmap.

### DIFF
--- a/config/lucerne.yml
+++ b/config/lucerne.yml
@@ -4,7 +4,7 @@ scrapers:
     item: body.layout-standard > div > div > div > div > div.frame.frame-default.frame-type-list.frame-layout-0 > div.event-list > section.event-list-box.event-link-to-details.lazyload-event-background > article
     fields:
       - name: "location"
-        value: "Schüür"
+        value: "Konzerthaus Schüür"
       - name: "city"
         value: "Lucerne"
       - name: country


### PR DESCRIPTION
Until now random schüür things around the country have been showing up as schüür. I just realized this because I added quicklinks to Mobilisons.ch.