### PR TITLE
Add explicit year to JazzOnze to prevent spurious listings for 2024

### DIFF
--- a/config/lausanne.yml
+++ b/config/lausanne.yml
@@ -389,7 +389,7 @@ scrapers:
 
   - name: JazzOnze
     url: https://jazzonzeplus.ch/
-    item: body > div.hfeed.site > div.site-content > section.blank_template.clearfix.parallax-section > div.mid-content > div.rfp-shortcode-6346.rfp-wrapper > div.rfp-grids.rfp-posts > div.edition-2023.item.md3.rfp-grid.rfp-item.sm4.xs12
+    item: body > div.hfeed.site > div.site-content > section.blank_template.clearfix.parallax-section > div.mid-content > div.rfp-shortcode-6346.rfp-wrapper > div.rfp-grids.rfp-posts > div.item.md3.rfp-grid.rfp-item
     fields:
       - name: "city"
         value: "Lausanne"
@@ -403,20 +403,24 @@ scrapers:
         type: date
         components:
           - covers:
+              year: true
+            location:
+              selector: ""
+              attr: class
+              regex_extract:
+                exp: "edition-[0-9]{4}"
+            layout:
+              - edition-2006
+          - covers:
               day: true
               month: true
-              year: true
             location:
               selector: div.program:nth-child(5) > span
               regex_extract:
-                exp: "(31|1er|2|3|4|5) (octobre|novembre)"
-            transform:
-              - type: regex-replace
-                regex: "$"
-                replace: " 2023"
+                exp: "[0-9]{1,2}(er)? [a-z]+"
             layout:
-              - "2 January 2006"
-              - "2er January 2006"
+              - "2 January"
+              - "2er January"
           - covers:
               time: true
             location:

--- a/config/lausanne.yml
+++ b/config/lausanne.yml
@@ -405,13 +405,18 @@ scrapers:
           - covers:
               day: true
               month: true
+              year: true
             location:
               selector: div.program:nth-child(5) > span
               regex_extract:
                 exp: "(31|1er|2|3|4|5) (octobre|novembre)"
+            transform:
+              - type: regex-replace
+                regex: "$"
+                replace: " 2023"
             layout:
-              - "2 January"
-              - "2er January"
+              - "2 January 2006"
+              - "2er January 2006"
           - covers:
               time: true
             location:


### PR DESCRIPTION
We'll have to update this in the fall of course. Perhaps I will drop them a line to suggest that they include the year consistently next year.