### PR TITLE
Fixed the URL field, and added imageUrl to DasGleis

### DIFF
--- a/config/zurich.yml
+++ b/config/zurich.yml
@@ -2201,7 +2201,15 @@ scrapers:
       - name: sourceUrl
         value: https://www.dasgleis.ch/
       - name: url
-        value: https://www.dasgleis.ch/
+        type: url
+        location:
+          - selector: div.EventList_eventHeader__eiGxm
+            attr: data-custom-prop
+      - name: imageUrl
+        type: url
+        location:
+          - selector: img.EventList_eventImage__oOks3
+            attr: data-src
       - name: title
         type: text
         location:


### PR DESCRIPTION
Das Gleis has one of the most annoying websites ever with all the whirlygigs that you have to move out of the way one-by-one. We're saving them from themselves. I suppose.

I mean they're kind of fun - the first time.