### PR TITLE
The images moved in the template. This fixes them.

### DIFF
--- a/config/lausanne.yml
+++ b/config/lausanne.yml
@@ -254,7 +254,7 @@ scrapers:
         type: url
         can_be_empty: true
         location:
-          selector: a.image > picture > source
+          selector: a.image > img
           attr: data-lazy-srcset
           regex_extract:
             exp: "[^ ]+"


### PR DESCRIPTION
This was causing some issues downstream. I wonder if a using blank field for the imageUrl when the image cannot be found might not be better than using the base URL.