### PR TITLE
Mascotte seem to have changed their image location.

### DIFF
--- a/config/zurich.yml
+++ b/config/zurich.yml
@@ -265,7 +265,7 @@ scrapers:
       - name: "imageUrl"
         type: "url"
         location:
-          selector: img
+          selector: ".nu-e-flyer img"
           attr: src
       - name: "url"
         type: "url"


### PR DESCRIPTION
I noticed that the Winehouse band image wasn't working correctly in Mobilisons.ch, so I checked and it turns out that they moved the images, so all we were getting was stills from YouTube.