### PR TITLE
Added image URLs for a couple that are problematic for the mobilisons importer

### DIFF
--- a/config/bulle.yml
+++ b/config/bulle.yml
@@ -13,6 +13,8 @@ scrapers:
         value: "Ebullition"
       - name: "sourceUrl"
         value: "https://ebull.ch/fr"
+      - name: imageUrl
+        value: https://www.fusions.ch/ebullition/img/ebullition_logo.gif
       - name: title
         type: text
         location:

--- a/config/zurich.yml
+++ b/config/zurich.yml
@@ -926,6 +926,13 @@ scrapers:
         type: "url"
         location:
           selector: "h2 a"
+      - name: "imageUrl"
+        type: "url"
+        location:
+          selector: ".event-summary-image > a > img"
+          attr: srcset
+          regex_extract:
+            exp: "[^ ]+"
       - name: "comment"
         location:
           selector: "div.col-md-8 > p:nth-child(6)"


### PR DESCRIPTION
Tested with goskyr v0.0.0-20260113211904-9b5968b0bc99.

The image for ebullition is static, but that's better than having to guess in the importer.