### PR TITLE
Peppi Guggenheim have switched to using Google Calendar

### DIFF
--- a/config/berlin.yml
+++ b/config/berlin.yml
@@ -385,8 +385,8 @@ scrapers:
         date_language: de_DE
 
   - name: PeppiGuggenheim
-    url: https://www.peppi-guggenheim.de/?post_type=tribe_events
-    item: div.tribe-common-g-col.tribe-events-calendar-list__event-details
+    url: https://calendar.google.com/calendar/u/0/embed?height=500&wkst=2&ctz=Europe/Berlin&mode=AGENDA&showPrint=0&src=am4yaDR0cmYxbjN1M3VnNG1oOXZrMWMwczRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ
+    item: main > div > div > div > div
     fields:
       - name: "type"
         value: "concert"
@@ -397,34 +397,36 @@ scrapers:
       - name: "location"
         value: "Gretchen"
       - name: "sourceUrl"
-        value: "https://www.peppi-guggenheim.de/?post_type=tribe_events"
+        value: https://calendar.google.com/calendar/u/0/embed?height=500&wkst=2&ctz=Europe/Berlin&mode=AGENDA&showPrint=0&src=am4yaDR0cmYxbjN1M3VnNG1oOXZrMWMwczRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ
+      - name: url
+        value: https://peppi-guggenheim.de/
       - name: title
         type: text
         location:
-          - selector: h3.tribe-common-h4--min-medium.tribe-common-h6.tribe-events-calendar-list__event-title > a.tribe-common-anchor-thin.tribe-events-calendar-list__event-title-link
-      - name: comment
-        location:
-          - selector: div > p
-        can_be_empty: true
-      - name: url
-        type: url
-        location:
-          - selector: h3.tribe-common-h4--min-medium.tribe-common-h6.tribe-events-calendar-list__event-title > a.tribe-common-anchor-thin.tribe-events-calendar-list__event-title-link
-            attr: href
+          - selector: div > div:nth-child(2) > div:nth-child(2) > div
+            entire_subtree: true
       - name: date
         type: date
         components:
           - covers:
               day: true
               month: true
+            location:
+              selector: div > div > h2 > div
+              attr: aria-label
+            layout:
+              - "Monday, January 2"
+          - covers:
               time: true
             location:
-              selector: div.tribe-common-b2.tribe-events-calendar-list__event-datetime-wrapper > time.tribe-events-calendar-list__event-datetime > span.tribe-event-date-start
+              default: 20:00
             layout:
-              - January 2 @ 15:04
+              - 15:04
         date_location: CET
         date_language: de_DE
         guess_year: true
+    fetcher:
+      type: dynamic
 
   - name: SO36
     url: https://www.so36.com/


### PR DESCRIPTION
It would be a lot cleaner to use the Google calendar API and jq or something to transfer this data to the concertcloud API, but until we have that capability this will do.