### PR TITLE
Added the promotor Loft

### DIFF
--- a/config/berlin.yml
+++ b/config/berlin.yml
@@ -932,3 +932,86 @@ scrapers:
         location:
           - selector: img
             attr: src
+
+scrapers:
+  - name: LoftProductions
+    url: https://loft.de/
+    item: section.events-grid > div.grid > a.grid-item
+    fields:
+      - name: "type"
+        value: "concert"
+      - name: "city"
+        value: "Berlin"
+      - name: "country"
+        value: "Germany"
+      - name: url
+        type: url
+        location:
+          - selector: ""
+            attr: href
+            # examples: ['https://loft.de/event/20260815-agnes-obel/', 'https://loft.de/event/20260815-rave-the-planet-afterparty/', 'https://loft.de/event/20260817-evening-elephants/', 'https://loft.de/event/20260818-fresse-auf-fuer-queere-freiheit/']
+      - name: imageUrl
+        type: url
+        location:
+          - selector: div.grid-image.outline-fix:nth-child(2) > img
+            attr: src
+            # examples: ['https://loft.de/wp-content/uploads/2024/11/agnes-obel-2025-landscape-alex-bruel-flagstad-1-600x400.webp', 'https://loft.de/wp-content/uploads/2026/04/rtp-afterparty2026-header-1920x1280-ohne-text-600x400.webp', 'https://loft.de/wp-content/uploads/2026/06/eveningelephants-600x400.webp', 'https://loft.de/wp-content/uploads/2026/08/fresseaufloft-600x400.webp']
+      - name: title
+        type: text
+        location:
+          - selector: div.grid-title:nth-child(3)
+            # examples: [Agnes Obel, Rave The Planet - Official Afterparty, Evening Elephants, Fresse auf für queere Freiheit]
+      - name: location
+        type: text
+        location:
+          - selector: div.grid-venue:nth-child(5) > div.venue-name
+            # examples: [Gärten der Welt, Columbiahalle, Kantine am Berghain, Columbiahalle]
+      - name: warnings
+        hide: true
+        type: text
+        can_be_empty: true
+        location:
+          - selector: div.grid-label:nth-child(6)
+            # examples: [Ausverkauft, Ausverkauft, Hochverlegt!, Verlegt!]
+      - name: date
+        type: date
+        on_subpage: url
+        components:
+          - covers:
+              day: true
+              month: true
+              year: true
+            location: 
+              selector: div.date
+              entire_subtree: true
+              regex_extract:
+                exp: "[A-z]{2}\\. [0-9]{2}\\. [A-zä]+ [0-9]{4}"
+            layout:
+              - "Mon. 02. January 2006"
+          - covers: 
+              time: true
+            location: 
+              selector: div.time > span.start
+              default: 20:00
+            layout: 
+              - "15:04"
+              - "Beginn 15"
+              - "Beginn 15:04"
+        date_location: "Europe/Berlin"
+        date_language: de_DE
+      - name: comment
+        type: text
+        on_subpage: url
+        can_be_empty: true
+        location:
+          - selector: div.event-text > div.event-text-inner
+            entire_subtree: true
+    filters:
+      - field: warnings
+        exp: "Hochverlegt!|Verlegt!"
+        match: false
+      - field: location
+        exp: "Astra|Badehaus|Frannz|Gretchen|Huxleys|SO36"
+        match: false
+    fetcher:
+      type: static

--- a/config/berlin.yml
+++ b/config/berlin.yml
@@ -863,7 +863,6 @@ scrapers:
         exp: "(?i)concert"
         match: true
 
-
   - name: WildAtHeart
     url: https://wildatheartberlin.de/concerts.php
     item: body > table > tbody > tr
@@ -901,7 +900,7 @@ scrapers:
             regex: '\"'
             replace: ""
           - type: regex-replace
-            regex: ' +'
+            regex: " +"
             replace: " "
       - name: dateText
         type: text
@@ -914,7 +913,7 @@ scrapers:
         date_language: de_DE
         guess_year: true
         components:
-          - covers: 
+          - covers:
               day: true
               month: true
             location:
@@ -952,14 +951,14 @@ scrapers:
         components:
           - covers:
               day: true
-            location: 
+            location:
               selector: div.event_date.grid-10.mobile-grid-30.tablet-grid-20 > div.event_day
             layout:
               - "02"
           - covers:
               month: true
               year: true
-            location: 
+            location:
               selector: div.event_date.grid-10.mobile-grid-30.tablet-grid-20 > div.event_month:nth-child(2)
             layout:
               - "Jan. 2006"
@@ -1014,7 +1013,7 @@ scrapers:
 
   - name: LoftProductions
     url: https://loft.de/
-    item: section.events-grid > div.grid > a.grid-item   
+    item: section.events-grid > div.grid > a.grid-item
     fields:
       - name: "type"
         value: "concert"
@@ -1022,6 +1021,8 @@ scrapers:
         value: "Berlin"
       - name: "country"
         value: "Germany"
+      - name: "sourceUrl"
+        value: "https://loft.de/"
       - name: url
         type: url
         location:
@@ -1059,19 +1060,19 @@ scrapers:
               day: true
               month: true
               year: true
-            location: 
+            location:
               selector: div.date
               entire_subtree: true
               regex_extract:
                 exp: "[A-z]{2}\\. [0-9]{2}\\. [A-zä]+ [0-9]{4}"
             layout:
               - "Mon. 02. January 2006"
-          - covers: 
+          - covers:
               time: true
-            location: 
+            location:
               selector: div.time > span.start
               default: 20:00
-            layout: 
+            layout:
               - "15:04"
               - "Beginn 15"
               - "Beginn 15:04"


### PR DESCRIPTION
It seems that in Berlin, kind of like London, some of the big halls no longer handle their own bookings, but instead there are these promotor who do the hard work of organizing with touring acts, etc.

I've filtered out those venues for which we already have good scrapers.

FYI, this came out of an attempt to build a scraper for columbiahalle, which handles the year and month in a way that makes scraping difficult.