### PR TITLE
This scraper originally ignored the event time, using a default.

### DIFF
--- a/config/basel.yml
+++ b/config/basel.yml
@@ -28,11 +28,10 @@ scrapers:
           - selector: ul.ical > a
         can_be_empty: true
       - name: mailUrl
-        type: text
+        type: url
         location:
           - selector: ul.ical > li > a:nth-child(2)
             attr: href
-            entire_subtree: true
         can_be_empty: true
       - name: date
         type: date

--- a/config/basel.yml
+++ b/config/basel.yml
@@ -27,22 +27,32 @@ scrapers:
         location:
           - selector: ul.ical > a
         can_be_empty: true
+      - name: mailUrl
+        type: text
+        location:
+          - selector: ul.ical > li > a:nth-child(2)
+            attr: href
+            entire_subtree: true
+        can_be_empty: true
       - name: date
         type: date
-        on_subpage: icalUrl
         components:
           - covers:
               day: true
               month: true
               year: true
             location:
-              selector: select > option
+              selector: ul.ical > li > a:nth-child(2)
+              attr: href
               regex_extract:
                 exp: "[0-9]{2}\\.[0-9]{2}\\.[0-9]{4}"
             layout: ["2.1.2006"]
           - covers:
               time: true
             location:
+              selector: ul.eventtime > li > strong
+              regex_extract:
+                exp: "[0-9]{2}:[0-9]{2}"
               default: "20:30"
             layout:
               - "15:04"


### PR DESCRIPTION
But I found a way to include it. This is important, because sometimes there are two events in the same evening.