### PR TITLE
Split X-TRA and its Musikcafe, and make event times more resiliant

### DIFF
--- a/config/zurich.yml
+++ b/config/zurich.yml
@@ -649,8 +649,6 @@ scrapers:
       - type: click # load more events
         selector: div.events > a.more
     fields:
-      - name: "location"
-        value: "X-TRA"
       - name: "city"
         value: "Zurich"
       - name: country
@@ -672,6 +670,18 @@ scrapers:
         location:
           selector: ".left .content p"
           max_length: 200
+      - name: "location"
+        on_subpage: "url"
+        location:
+          selector: div.event > div > div.right > ul.info
+          entire_subtree: true
+          regex_extract: 
+            exp: "LocationX-TRA( Musikcafe)?"
+          default: "X-TRA"
+        transform:
+          - type: regex-replace
+            regex: "Location"
+            replace: ""
       - name: genresText
         on_subpage: "url"
         location:
@@ -698,7 +708,8 @@ scrapers:
           - covers:
               time: true
             location:
-              selector: ".time > li:nth-child(2) > strong"
+              selector: ".time > li:nth-last-child(1) > strong"
+              default: "7.00 pm"
             transform:
               - type: regex-replace
                 regex: "p\\.m\\."


### PR DESCRIPTION
X-TRA hosts two venues, and there are sometimes simultanious events. Both are present on OpenStreetMap, so the dry run works for everything.

At the same time I noticed that some event times weren't being picked up, because they lacked a doors-open time, making the start time the first of two time entries. So I switched to nth-last-child() which counts elements backwards. This seems to always work, so long as there is at least one time.

There's a single Sunday show in November which has no time at all. So I added a default at 19:00 since that's when they seem to run Sunday shows.