### PR TITLE
Add new Venue Stadtcasino Basel

### DIFF
--- a/config/basel.yml
+++ b/config/basel.yml
@@ -322,3 +322,358 @@ scrapers:
         type: url
         location:
           - attr: href
+      
+
+  - name: "Stadtcasino Basel Blasmusik / Folklore"
+    url: https://www.stadtcasino-basel.ch/de/programm/veranstaltungen/?c=11
+    item: div.hide.tiles-wrapper > div.event > div.container:nth-child(2)
+    fields:
+      - name: "location"
+        value: "Stadtcasino Basel"
+      - name: "city"
+        value: "Basel"
+      - name: country
+        value: Switzerland
+      - name: "sourceURL"
+        type: url
+        value: "https://www.stadtcasino-basel.ch"
+      - name: "type"
+        value: "concert"
+      - name: "genresText"
+        value: "Blasmusik / Folklore"
+      - name: "imageUrl"
+        type: url
+        on_subpage: url
+        location:
+          - selector: div.col-md-6.col-center > img
+            attr: src
+            # examples: [https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_12_Theaterplatzquartier_Fest_1_9e0f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_1_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_2_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_3_8e4f3d7a5b.jpg]
+      
+      - name: url
+        type: url
+        location:
+          - selector: div.row > div.col-sm-10:nth-child(2) > a
+            attr: href
+            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
+      - name: title
+        type: text
+        location:
+          - selector: div.row > div.col-sm-10:nth-child(2) > a > h2
+            # examples: [Theaterplatz-Fest, Führung Stadtcasino Basel, Führung Stadtcasino Basel, Führung Stadtcasino Basel]
+      - name: comment
+        type: text
+        location:
+          - selector: div.row > div.col-sm-10:nth-child(2) > a > p
+            # examples: [Mit vielfältigem Programmangebot, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur]
+        can_be_empty: true
+      - name: "url"
+        type: url
+        location:
+          - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default
+            attr: href
+            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
+      - name: "tickets"
+        type: url
+        location:
+          - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default:nth-child(2)
+            attr: href
+            # examples: ['https://www.basel.com/de/veranstaltungskalender/stadtcasino-basel-weltklasseakustik-stararchitektur-5b89371b20', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-12&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-13&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://442hz.com/de/ensembles/Kammerorchester_Basel/shop/event/165106/#event']
+        can_be_empty: true
+      - name: date
+        type: date
+        on_subpage: url
+        components:
+          - covers:
+              day: true
+            location:
+              selector: div.col-md-6.text-center > span.day
+            layout:
+              - "2"
+      
+          - covers:
+              month: true
+              year: true
+            location:
+              selector: div.col-md-6.text-center > span.month
+            layout:
+              - "January 2006"
+      
+          - covers:
+              time: true
+            location:
+              selector: div.col-md-6.text-center > ul.event-details > li:nth-child(2)
+              regex_extract:
+                exp: ".*Beginn ([0-9]{1,2}\\.[0-9]{2}) h.*"
+            layout:
+              - "Beginn 15.04 h"
+      
+        date_location: "Europe/Berlin"
+        date_language: de_DE
+        guess_year: false
+    fetcher:
+      type: static
+  
+  - name: Stadtcasino Basel Klassik
+    url: https://www.stadtcasino-basel.ch/de/programm/veranstaltungen/?c=1
+    item: div.hide.tiles-wrapper > div.event > div.container:nth-child(2)
+    fields:
+      - name: "location"
+        value: "Stadtcasino Basel"
+      - name: "city"
+        value: "Basel"
+      - name: country
+        value: Switzerland
+      - name: "sourceURL"
+        type: url
+        value: "https://www.stadtcasino-basel.ch"
+      - name: "type"
+        value: "concert"
+      - name: "genresText"
+        value: "Klassik"
+      - name: "imageUrl"
+        type: url
+        on_subpage: url
+        location:
+          - selector: div.col-md-6.col-center > img
+            attr: src
+            # examples: [https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_12_Theaterplatzquartier_Fest_1_9e0f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_1_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_2_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_3_8e4f3d7a5b.jpg]
+      
+      - name: url
+        type: url
+        location:
+          - selector: div.row > div.col-sm-10:nth-child(2) > a
+            attr: href
+            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
+      - name: title
+        type: text
+        location:
+          - selector: div.row > div.col-sm-10:nth-child(2) > a > h2
+            # examples: [Theaterplatz-Fest, Führung Stadtcasino Basel, Führung Stadtcasino Basel, Führung Stadtcasino Basel]
+      - name: comment
+        type: text
+        location:
+          - selector: div.row > div.col-sm-10:nth-child(2) > a > p
+            # examples: [Mit vielfältigem Programmangebot, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur]
+        can_be_empty: true
+      - name: "url"
+        type: url
+        location:
+          - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default
+            attr: href
+            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
+      - name: "tickets"
+        type: url
+        location:
+          - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default:nth-child(2)
+            attr: href
+            # examples: ['https://www.basel.com/de/veranstaltungskalender/stadtcasino-basel-weltklasseakustik-stararchitektur-5b89371b20', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-12&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-13&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://442hz.com/de/ensembles/Kammerorchester_Basel/shop/event/165106/#event']
+        can_be_empty: true
+      - name: date
+        type: date
+        on_subpage: url
+        components:
+          - covers:
+              day: true
+            location:
+              selector: div.col-md-6.text-center > span.day
+            layout:
+              - "2"
+      
+          - covers:
+              month: true
+              year: true
+            location:
+              selector: div.col-md-6.text-center > span.month
+            layout:
+              - "January 2006"
+      
+          - covers:
+              time: true
+            location:
+              selector: div.col-md-6.text-center > ul.event-details > li:nth-child(2)
+              regex_extract:
+                exp: ".*Beginn ([0-9]{1,2}\\.[0-9]{2}) h.*"
+            layout:
+              - "Beginn 15.04 h"
+      
+        date_location: "Europe/Berlin"
+        date_language: de_DE
+        guess_year: false
+    fetcher:
+      type: static
+  - name: Stadtcasino Basel Jazz / Worldmusic
+    url: https://www.stadtcasino-basel.ch/de/programm/veranstaltungen/?c=6
+    item: div.hide.tiles-wrapper > div.event > div.container:nth-child(2)
+    fields:
+      - name: "location"
+        value: "Stadtcasino Basel"
+      - name: "city"
+        value: "Basel"
+      - name: country
+        value: Switzerland
+      - name: "sourceURL"
+        type: url
+        value: "https://www.stadtcasino-basel.ch"
+      - name: "type"
+        value: "concert"
+      - name: "genresText"
+        value: "Jazz / Worldmusic"
+      - name: "imageUrl"
+        type: url
+        on_subpage: url
+        location:
+          - selector: div.col-md-6.col-center > img
+            attr: src
+            # examples: [https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_12_Theaterplatzquartier_Fest_1_9e0f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_1_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_2_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_3_8e4f3d7a5b.jpg]
+      
+      - name: url
+        type: url
+        location:
+          - selector: div.row > div.col-sm-10:nth-child(2) > a
+            attr: href
+            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
+      - name: title
+        type: text
+        location:
+          - selector: div.row > div.col-sm-10:nth-child(2) > a > h2
+            # examples: [Theaterplatz-Fest, Führung Stadtcasino Basel, Führung Stadtcasino Basel, Führung Stadtcasino Basel]
+      - name: comment
+        type: text
+        location:
+          - selector: div.row > div.col-sm-10:nth-child(2) > a > p
+            # examples: [Mit vielfältigem Programmangebot, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur]
+        can_be_empty: true
+      - name: "url"
+        type: url
+        location:
+          - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default
+            attr: href
+            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
+      - name: "tickets"
+        type: url
+        location:
+          - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default:nth-child(2)
+            attr: href
+            # examples: ['https://www.basel.com/de/veranstaltungskalender/stadtcasino-basel-weltklasseakustik-stararchitektur-5b89371b20', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-12&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-13&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://442hz.com/de/ensembles/Kammerorchester_Basel/shop/event/165106/#event']
+        can_be_empty: true
+      - name: date
+        type: date
+        on_subpage: url
+        components:
+          - covers:
+              day: true
+            location:
+              selector: div.col-md-6.text-center > span.day
+            layout:
+              - "2"
+      
+          - covers:
+              month: true
+              year: true
+            location:
+              selector: div.col-md-6.text-center > span.month
+            layout:
+              - "January 2006"
+      
+          - covers:
+              time: true
+            location:
+              selector: div.col-md-6.text-center > ul.event-details > li:nth-child(2)
+              regex_extract:
+                exp: ".*Beginn ([0-9]{1,2}\\.[0-9]{2}) h.*"
+            layout:
+              - "Beginn 15.04 h"
+      
+        date_location: "Europe/Berlin"
+        date_language: de_DE
+        guess_year: false
+    fetcher:
+      type: static
+  - name: Stadtcasino Basel Musical
+    url: https://www.stadtcasino-basel.ch/de/programm/veranstaltungen/?c=21
+    item: div.hide.tiles-wrapper > div.event > div.container:nth-child(2)
+    fields:
+      - name: "location"
+        value: "Stadtcasino Basel"
+      - name: "city"
+        value: "Basel"
+      - name: "country"
+        value: "Switzerland"
+      - name: "sourceURL"
+        type: url
+        value: "https://www.stadtcasino-basel.ch"
+      - name: "type"
+        value: "concert"
+      - name: "genresText"
+        value: "Musical"
+      - name: "imageUrl"
+        type: url
+        on_subpage: url
+        location:
+          - selector: div.col-md-6.col-center > img
+            attr: src
+            # examples: [https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_12_Theaterplatzquartier_Fest_1_9e0f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_1_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_2_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_3_8e4f3d7a5b.jpg]
+      
+      - name: url
+        type: url
+        location:
+          - selector: div.row > div.col-sm-10:nth-child(2) > a
+            attr: href
+            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
+      - name: title
+        type: text
+        location:
+          - selector: div.row > div.col-sm-10:nth-child(2) > a > h2
+            # examples: [Theaterplatz-Fest, Führung Stadtcasino Basel, Führung Stadtcasino Basel, Führung Stadtcasino Basel]
+      - name: comment
+        type: text
+        location:
+          - selector: div.row > div.col-sm-10:nth-child(2) > a > p
+            # examples: [Mit vielfältigem Programmangebot, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur]
+        can_be_empty: true
+      - name: "url"
+        type: url
+        location:
+          - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default
+            attr: href
+            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
+      - name: "tickets"
+        type: url
+        location:
+          - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default:nth-child(2)
+            attr: href
+            # examples: ['https://www.basel.com/de/veranstaltungskalender/stadtcasino-basel-weltklasseakustik-stararchitektur-5b89371b20', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-12&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-13&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://442hz.com/de/ensembles/Kammerorchester_Basel/shop/event/165106/#event']
+        can_be_empty: true
+      - name: date
+        type: date
+        on_subpage: url
+        components:
+          - covers:
+              day: true
+            location:
+              selector: div.col-md-6.text-center > span.day
+            layout:
+              - "2"
+      
+          - covers:
+              month: true
+              year: true
+            location:
+              selector: div.col-md-6.text-center > span.month
+            layout:
+              - "January 2006"
+      
+          - covers:
+              time: true
+            location:
+              selector: div.col-md-6.text-center > ul.event-details > li:nth-child(2)
+              regex_extract:
+                exp: ".*Beginn ([0-9]{1,2}\\.[0-9]{2}) h.*"
+            layout:
+              - "Beginn 15.04 h"
+      
+        date_location: "Europe/Berlin"
+        date_language: de_DE
+        guess_year: false
+    fetcher:
+      type: static

--- a/config/basel.yml
+++ b/config/basel.yml
@@ -322,7 +322,6 @@ scrapers:
         type: url
         location:
           - attr: href
-      
 
   - name: "Stadtcasino Basel Blasmusik / Folklore"
     url: https://www.stadtcasino-basel.ch/de/programm/veranstaltungen/?c=11
@@ -346,38 +345,31 @@ scrapers:
         on_subpage: url
         location:
           - selector: div.col-md-6.col-center > img
-            attr: src
-            # examples: [https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_12_Theaterplatzquartier_Fest_1_9e0f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_1_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_2_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_3_8e4f3d7a5b.jpg]
-      
+            attr: src      
       - name: url
         type: url
         location:
           - selector: div.row > div.col-sm-10:nth-child(2) > a
             attr: href
-            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
       - name: title
         type: text
         location:
           - selector: div.row > div.col-sm-10:nth-child(2) > a > h2
-            # examples: [Theaterplatz-Fest, Führung Stadtcasino Basel, Führung Stadtcasino Basel, Führung Stadtcasino Basel]
       - name: comment
         type: text
         location:
           - selector: div.row > div.col-sm-10:nth-child(2) > a > p
-            # examples: [Mit vielfältigem Programmangebot, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur]
         can_be_empty: true
       - name: "url"
         type: url
         location:
           - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default
             attr: href
-            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
       - name: "tickets"
         type: url
         location:
           - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default:nth-child(2)
             attr: href
-            # examples: ['https://www.basel.com/de/veranstaltungskalender/stadtcasino-basel-weltklasseakustik-stararchitektur-5b89371b20', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-12&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-13&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://442hz.com/de/ensembles/Kammerorchester_Basel/shop/event/165106/#event']
         can_be_empty: true
       - name: date
         type: date
@@ -389,7 +381,6 @@ scrapers:
               selector: div.col-md-6.text-center > span.day
             layout:
               - "2"
-      
           - covers:
               month: true
               year: true
@@ -397,7 +388,6 @@ scrapers:
               selector: div.col-md-6.text-center > span.month
             layout:
               - "January 2006"
-      
           - covers:
               time: true
             location:
@@ -406,7 +396,6 @@ scrapers:
                 exp: ".*Beginn ([0-9]{1,2}\\.[0-9]{2}) h.*"
             layout:
               - "Beginn 15.04 h"
-      
         date_location: "Europe/Berlin"
         date_language: de_DE
         guess_year: false
@@ -435,38 +424,31 @@ scrapers:
         on_subpage: url
         location:
           - selector: div.col-md-6.col-center > img
-            attr: src
-            # examples: [https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_12_Theaterplatzquartier_Fest_1_9e0f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_1_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_2_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_3_8e4f3d7a5b.jpg]
-      
+            attr: src      
       - name: url
         type: url
         location:
           - selector: div.row > div.col-sm-10:nth-child(2) > a
             attr: href
-            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
       - name: title
         type: text
         location:
           - selector: div.row > div.col-sm-10:nth-child(2) > a > h2
-            # examples: [Theaterplatz-Fest, Führung Stadtcasino Basel, Führung Stadtcasino Basel, Führung Stadtcasino Basel]
       - name: comment
         type: text
         location:
           - selector: div.row > div.col-sm-10:nth-child(2) > a > p
-            # examples: [Mit vielfältigem Programmangebot, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur]
         can_be_empty: true
       - name: "url"
         type: url
         location:
           - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default
             attr: href
-            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
       - name: "tickets"
         type: url
         location:
           - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default:nth-child(2)
             attr: href
-            # examples: ['https://www.basel.com/de/veranstaltungskalender/stadtcasino-basel-weltklasseakustik-stararchitektur-5b89371b20', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-12&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-13&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://442hz.com/de/ensembles/Kammerorchester_Basel/shop/event/165106/#event']
         can_be_empty: true
       - name: date
         type: date
@@ -478,7 +460,6 @@ scrapers:
               selector: div.col-md-6.text-center > span.day
             layout:
               - "2"
-      
           - covers:
               month: true
               year: true
@@ -486,7 +467,6 @@ scrapers:
               selector: div.col-md-6.text-center > span.month
             layout:
               - "January 2006"
-      
           - covers:
               time: true
             location:
@@ -495,12 +475,12 @@ scrapers:
                 exp: ".*Beginn ([0-9]{1,2}\\.[0-9]{2}) h.*"
             layout:
               - "Beginn 15.04 h"
-      
         date_location: "Europe/Berlin"
         date_language: de_DE
         guess_year: false
     fetcher:
       type: static
+
   - name: Stadtcasino Basel Jazz / Worldmusic
     url: https://www.stadtcasino-basel.ch/de/programm/veranstaltungen/?c=6
     item: div.hide.tiles-wrapper > div.event > div.container:nth-child(2)
@@ -524,37 +504,30 @@ scrapers:
         location:
           - selector: div.col-md-6.col-center > img
             attr: src
-            # examples: [https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_12_Theaterplatzquartier_Fest_1_9e0f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_1_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_2_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_3_8e4f3d7a5b.jpg]
-      
       - name: url
         type: url
         location:
           - selector: div.row > div.col-sm-10:nth-child(2) > a
             attr: href
-            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
       - name: title
         type: text
         location:
           - selector: div.row > div.col-sm-10:nth-child(2) > a > h2
-            # examples: [Theaterplatz-Fest, Führung Stadtcasino Basel, Führung Stadtcasino Basel, Führung Stadtcasino Basel]
       - name: comment
         type: text
         location:
           - selector: div.row > div.col-sm-10:nth-child(2) > a > p
-            # examples: [Mit vielfältigem Programmangebot, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur]
         can_be_empty: true
       - name: "url"
         type: url
         location:
           - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default
             attr: href
-            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
       - name: "tickets"
         type: url
         location:
           - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default:nth-child(2)
             attr: href
-            # examples: ['https://www.basel.com/de/veranstaltungskalender/stadtcasino-basel-weltklasseakustik-stararchitektur-5b89371b20', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-12&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-13&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://442hz.com/de/ensembles/Kammerorchester_Basel/shop/event/165106/#event']
         can_be_empty: true
       - name: date
         type: date
@@ -566,7 +539,6 @@ scrapers:
               selector: div.col-md-6.text-center > span.day
             layout:
               - "2"
-      
           - covers:
               month: true
               year: true
@@ -574,7 +546,6 @@ scrapers:
               selector: div.col-md-6.text-center > span.month
             layout:
               - "January 2006"
-      
           - covers:
               time: true
             location:
@@ -583,12 +554,12 @@ scrapers:
                 exp: ".*Beginn ([0-9]{1,2}\\.[0-9]{2}) h.*"
             layout:
               - "Beginn 15.04 h"
-      
         date_location: "Europe/Berlin"
         date_language: de_DE
         guess_year: false
     fetcher:
       type: static
+
   - name: Stadtcasino Basel Musical
     url: https://www.stadtcasino-basel.ch/de/programm/veranstaltungen/?c=21
     item: div.hide.tiles-wrapper > div.event > div.container:nth-child(2)
@@ -612,37 +583,30 @@ scrapers:
         location:
           - selector: div.col-md-6.col-center > img
             attr: src
-            # examples: [https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_12_Theaterplatzquartier_Fest_1_9e0f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_1_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_2_8e4f3d7a5b.jpg, https://www.stadtcasino-basel.ch/fileadmin/_processed_/csm_2026_09_13_Fuehrung_Stadtcasino_Basel_3_8e4f3d7a5b.jpg]
-      
       - name: url
         type: url
         location:
           - selector: div.row > div.col-sm-10:nth-child(2) > a
             attr: href
-            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
       - name: title
         type: text
         location:
           - selector: div.row > div.col-sm-10:nth-child(2) > a > h2
-            # examples: [Theaterplatz-Fest, Führung Stadtcasino Basel, Führung Stadtcasino Basel, Führung Stadtcasino Basel]
       - name: comment
         type: text
         location:
           - selector: div.row > div.col-sm-10:nth-child(2) > a > p
-            # examples: [Mit vielfältigem Programmangebot, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur, Weltklasseakustik & Stararchitektur]
         can_be_empty: true
       - name: "url"
         type: url
         location:
           - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default
             attr: href
-            # examples: [/de/programm/veranstaltungen/12092026_theaterplatzquartier_fest/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-1600-uhr/, /de/programm/veranstaltungen/fuhrung-stadtcasino-basel-130926/]
       - name: "tickets"
         type: url
         location:
           - selector: div.hidden-xs.row.text-right:nth-child(2) > div.col-xs-12 > a.btn.btn-default:nth-child(2)
             attr: href
-            # examples: ['https://www.basel.com/de/veranstaltungskalender/stadtcasino-basel-weltklasseakustik-stararchitektur-5b89371b20', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-12&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://www.basel.com/de/ticket-buchen?config=basel_tds&objectid=TDS00020012758516798&startDate=2026-09-13&language=de&objectName=Stadtcasino%2520Basel%2520%25E2%2580%2593%2520Weltklasseakustik%2520%2', 'https://442hz.com/de/ensembles/Kammerorchester_Basel/shop/event/165106/#event']
         can_be_empty: true
       - name: date
         type: date
@@ -654,7 +618,6 @@ scrapers:
               selector: div.col-md-6.text-center > span.day
             layout:
               - "2"
-      
           - covers:
               month: true
               year: true
@@ -662,7 +625,6 @@ scrapers:
               selector: div.col-md-6.text-center > span.month
             layout:
               - "January 2006"
-      
           - covers:
               time: true
             location:
@@ -671,7 +633,6 @@ scrapers:
                 exp: ".*Beginn ([0-9]{1,2}\\.[0-9]{2}) h.*"
             layout:
               - "Beginn 15.04 h"
-      
         date_location: "Europe/Berlin"
         date_language: de_DE
         guess_year: false


### PR DESCRIPTION
Hi,
I added several scrapers for the Stadtcasino Basel. Besides Concerts it has other events which I was only able to filter via query parameters. That is why there are several scrapers. If there is a slicker solution, feel free to adjust it.